### PR TITLE
new versions of alpine uses python 3.11 and pip3 requires the flag --…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:latest
 
 RUN apk add --no-cache python3 py3-pip curl
-RUN pip3 install --upgrade pip \
-  && pip3 install --no-cache-dir awscli \
+RUN pip3 install --upgrade pip --break-system-packages \
+  && pip3 install --no-cache-dir awscli --break-system-packages \
   && rm -rf /var/cache/apk/*
 RUN curl -Ls -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl -o /usr/bin/kubectl \
   && chmod +x /usr/bin/kubectl


### PR DESCRIPTION
…break-system-packages to be passed https://stackoverflow.com/questions/75608323/how-do-i-solve-error-externally-managed-environment-every-time-i-use-pip-3